### PR TITLE
Use bottle neck

### DIFF
--- a/lib/network/rtpose_vgg.py
+++ b/lib/network/rtpose_vgg.py
@@ -23,10 +23,39 @@ def make_stages(cfg_dict):
                 layers += [nn.MaxPool2d(kernel_size=v[0], stride=v[1],
                                         padding=v[2])]
             else:
-                conv2d = nn.Conv2d(in_channels=v[0], out_channels=v[1],
-                                   kernel_size=v[2], stride=v[3],
-                                   padding=v[4])
-                layers += [conv2d, nn.ReLU(inplace=True)]
+                UseBottleNeck = 1
+                if ('_bot' not in k):
+                    UseBottleNeck = 0
+
+                if 0 == UseBottleNeck:
+                    ## This is original conv 3x3 at channel size 128
+                    conv2d = nn.Conv2d(in_channels=v[0],
+                                        out_channels=v[1],
+                                        kernel_size=v[2],
+                                        stride=v[3],
+                                        padding=v[4])
+                    layers += [conv2d, nn.ReLU(inplace=True)]
+
+                else :
+                    bottleNeckChannelSize = 24
+                    conv2dreduce = nn.Conv2d(in_channels=v[0],
+                                            out_channels=bottleNeckChannelSize,
+                                            kernel_size=1,
+                                            stride=1,
+                                            padding=0)
+                    conv2d       = nn.Conv2d(in_channels=bottleNeckChannelSize,
+                                            out_channels=bottleNeckChannelSize,
+                                            kernel_size=v[2],
+                                            stride=v[3],
+                                            padding=v[4])
+                    conv2dextand = nn.Conv2d(in_channels=bottleNeckChannelSize,
+                                            out_channels=v[1],
+                                            kernel_size=1,
+                                            stride=1,
+                                            padding=0)
+
+                    layers += [conv2dreduce, conv2d, conv2dextand, nn.ReLU(inplace=True)]
+
     one_ = list(cfg_dict[-1].keys())
     k = one_[0]
     v = cfg_dict[-1][k]
@@ -107,21 +136,21 @@ def get_model(trunk='vgg19'):
     # Stages 2 - 6
     for i in range(2, 7):
         blocks['block%d_1' % i] = [
-            {'Mconv1_stage%d_L1' % i: [185, 128, 7, 1, 3]},
-            {'Mconv2_stage%d_L1' % i: [128, 128, 7, 1, 3]},
-            {'Mconv3_stage%d_L1' % i: [128, 128, 7, 1, 3]},
-            {'Mconv4_stage%d_L1' % i: [128, 128, 7, 1, 3]},
-            {'Mconv5_stage%d_L1' % i: [128, 128, 7, 1, 3]},
+            {'Mconv1_stage%d_L1_bot' % i: [185, 128, 7, 1, 3]},
+            {'Mconv2_stage%d_L1_bot' % i: [128, 128, 7, 1, 3]},
+            {'Mconv3_stage%d_L1_bot' % i: [128, 128, 7, 1, 3]},
+            {'Mconv4_stage%d_L1_bot' % i: [128, 128, 7, 1, 3]},
+            {'Mconv5_stage%d_L1_bot' % i: [128, 128, 7, 1, 3]},
             {'Mconv6_stage%d_L1' % i: [128, 128, 1, 1, 0]},
             {'Mconv7_stage%d_L1' % i: [128, 38, 1, 1, 0]}
         ]
 
         blocks['block%d_2' % i] = [
-            {'Mconv1_stage%d_L2' % i: [185, 128, 7, 1, 3]},
-            {'Mconv2_stage%d_L2' % i: [128, 128, 7, 1, 3]},
-            {'Mconv3_stage%d_L2' % i: [128, 128, 7, 1, 3]},
-            {'Mconv4_stage%d_L2' % i: [128, 128, 7, 1, 3]},
-            {'Mconv5_stage%d_L2' % i: [128, 128, 7, 1, 3]},
+            {'Mconv1_stage%d_L2_bot' % i: [185, 128, 7, 1, 3]},
+            {'Mconv2_stage%d_L2_bot' % i: [128, 128, 7, 1, 3]},
+            {'Mconv3_stage%d_L2_bot' % i: [128, 128, 7, 1, 3]},
+            {'Mconv4_stage%d_L2_bot' % i: [128, 128, 7, 1, 3]},
+            {'Mconv5_stage%d_L2_bot' % i: [128, 128, 7, 1, 3]},
             {'Mconv6_stage%d_L2' % i: [128, 128, 1, 1, 0]},
             {'Mconv7_stage%d_L2' % i: [128, 19, 1, 1, 0]}
         ]


### PR DESCRIPTION
apply bottleneck model to stage 2~6

before
```
    (model3_1): Sequential(
      (0): Conv2d(185, 128, kernel_size=(7, 7), stride=(1, 1), padding=(3, 3))
      (1): ReLU(inplace=True)
      (2): Conv2d(128, 128, kernel_size=(7, 7), stride=(1, 1), padding=(3, 3))
      (3): ReLU(inplace=True)
      (4): Conv2d(128, 128, kernel_size=(7, 7), stride=(1, 1), padding=(3, 3))
      (5): ReLU(inplace=True)
      (6): Conv2d(128, 128, kernel_size=(7, 7), stride=(1, 1), padding=(3, 3))
      (7): ReLU(inplace=True)
      (8): Conv2d(128, 128, kernel_size=(7, 7), stride=(1, 1), padding=(3, 3))
      (9): ReLU(inplace=True)
      (10): Conv2d(128, 128, kernel_size=(1, 1), stride=(1, 1))
      (11): ReLU(inplace=True)
      (12): Conv2d(128, 38, kernel_size=(1, 1), stride=(1, 1))
    )
```

after
```diff
  (model3_1): Sequential(
+   (0): Conv2d(185, 24, kernel_size=(1, 1), stride=(1, 1))
+   (1): Conv2d(24, 24, kernel_size=(7, 7), stride=(1, 1), padding=(3, 3))
+   (2): Conv2d(24, 128, kernel_size=(1, 1), stride=(1, 1))
    (3): ReLU(inplace=True)
+   (4): Conv2d(128, 24, kernel_size=(1, 1), stride=(1, 1))
+   (5): Conv2d(24, 24, kernel_size=(7, 7), stride=(1, 1), padding=(3, 3))
+   (6): Conv2d(24, 128, kernel_size=(1, 1), stride=(1, 1))
    (7): ReLU(inplace=True)
+   (8): Conv2d(128, 24, kernel_size=(1, 1), stride=(1, 1))
+   (9): Conv2d(24, 24, kernel_size=(7, 7), stride=(1, 1), padding=(3, 3))
+   (10): Conv2d(24, 128, kernel_size=(1, 1), stride=(1, 1))
    (11): ReLU(inplace=True)
+   (12): Conv2d(128, 24, kernel_size=(1, 1), stride=(1, 1))
+   (13): Conv2d(24, 24, kernel_size=(7, 7), stride=(1, 1), padding=(3, 3))
+   (14): Conv2d(24, 128, kernel_size=(1, 1), stride=(1, 1))
    (15): ReLU(inplace=True)
+   (16): Conv2d(128, 24, kernel_size=(1, 1), stride=(1, 1))
+   (17): Conv2d(24, 24, kernel_size=(7, 7), stride=(1, 1), padding=(3, 3))
+   (18): Conv2d(24, 128, kernel_size=(1, 1), stride=(1, 1))
    (19): ReLU(inplace=True)
    (20): Conv2d(128, 128, kernel_size=(1, 1), stride=(1, 1))
    (21): ReLU(inplace=True)
    (22): Conv2d(128, 19, kernel_size=(1, 1), stride=(1, 1))
```